### PR TITLE
Expand state search

### DIFF
--- a/OCR API 2/app/services/e_way_bill.py
+++ b/OCR API 2/app/services/e_way_bill.py
@@ -1,5 +1,5 @@
 import re
-from app.services.ocr_utils import normalize_ascii, debug_print_lines
+from app.services.ocr_utils import normalize_ascii, debug_print_lines, STATE_REGEX
 
 def extract_eway_bill_fields(text):
     print("\n🧾 Processing: E-Way Bill")
@@ -71,15 +71,19 @@ def extract_eway_bill_fields(text):
     for i, line in enumerate(lines):
         norm = normalize_ascii(line)
         if "dispatch from" in norm:
-            for j in range(i, i+5):
-                if j < len(lines) and any(st in lines[j].upper() for st in ["MAHARASHTRA", "GUJARAT", "DELHI", "TAMIL", "KARNATAKA"]):
-                    result["From State"] = lines[j].strip().split()[-1].title()
-                    break
+            for j in range(i, i + 5):
+                if j < len(lines):
+                    match = STATE_REGEX.search(lines[j])
+                    if match:
+                        result["From State"] = match.group(1).title()
+                        break
         if "ship to" in norm:
-            for j in range(i, i+5):
-                if j < len(lines) and any(st in lines[j].upper() for st in ["MAHARASHTRA", "GUJARAT", "DELHI", "TAMIL", "KARNATAKA"]):
-                    result["To State"] = lines[j].strip().split()[-1].title()
-                    break
+            for j in range(i, i + 5):
+                if j < len(lines):
+                    match = STATE_REGEX.search(lines[j])
+                    if match:
+                        result["To State"] = match.group(1).title()
+                        break
 
     # 6️⃣ Material name / Plastic Category
     material_line = find(r"Product\s+Name\s+&\s+Desc[^\n]*\n\s*([A-Z\s&]+)")

--- a/OCR API 2/app/services/ocr_utils.py
+++ b/OCR API 2/app/services/ocr_utils.py
@@ -3,6 +3,52 @@ import re
 import unicodedata
 from PIL import Image
 
+# Common reference list of Indian state and union territory names
+INDIAN_STATES = [
+    "ANDHRA PRADESH",
+    "ARUNACHAL PRADESH",
+    "ASSAM",
+    "BIHAR",
+    "CHHATTISGARH",
+    "GOA",
+    "GUJARAT",
+    "HARYANA",
+    "HIMACHAL PRADESH",
+    "JHARKHAND",
+    "KARNATAKA",
+    "KERALA",
+    "MADHYA PRADESH",
+    "MAHARASHTRA",
+    "MANIPUR",
+    "MEGHALAYA",
+    "MIZORAM",
+    "NAGALAND",
+    "ODISHA",
+    "PUNJAB",
+    "RAJASTHAN",
+    "SIKKIM",
+    "TAMIL NADU",
+    "TELANGANA",
+    "TRIPURA",
+    "UTTAR PRADESH",
+    "UTTARAKHAND",
+    "WEST BENGAL",
+    "ANDAMAN AND NICOBAR ISLANDS",
+    "CHANDIGARH",
+    "DADRA AND NAGAR HAVELI AND DAMAN AND DIU",
+    "DELHI",
+    "JAMMU AND KASHMIR",
+    "LADAKH",
+    "LAKSHADWEEP",
+    "PUDUCHERRY",
+]
+
+# Regex pattern to match any of the above state names as whole words
+STATE_REGEX = re.compile(
+    r"\b(" + "|".join(re.escape(s) for s in INDIAN_STATES) + r")\b",
+    re.IGNORECASE,
+)
+
 def run_ocr(image_path):
     from google.cloud import vision  # Import inside function
     client = vision.ImageAnnotatorClient()  # Initialize here
@@ -137,18 +183,14 @@ def extract_states_from_blocks(lines):
         # print(f"🔍 At line {i}, cleaned line: '{clean_line}'")  # Log every line for debugging
 
         if clean_line == "from" and i + 2 < len(lines):
-            # print(f"📍 Found 'From' at line {i}: {line.strip()}")
-            # print(f"   Checking line {i+2} for state: {lines[i+2].strip()}")
-            match = re.search(r"\(([^)]+)\)", lines[i + 2])
+            match = STATE_REGEX.search(lines[i + 2])
             if match:
-                from_state = match.group(1).strip()
+                from_state = match.group(1).title()
 
         elif re.fullmatch(r"to", clean_line.strip()) and i + 2 < len(lines):
-            # print(f"📍 Found 'To' at line {i}: {line.strip()}")
-            # print(f"   Checking line {i+2} for state: {lines[i+2].strip()}")
-            match = re.search(r"\(([^)]+)\)", lines[i + 2])
+            match = STATE_REGEX.search(lines[i + 2])
             if match:
-                to_state = match.group(1).strip()
+                to_state = match.group(1).title()
 
 
     return from_state, to_state

--- a/OCR API/e_way_bill.py
+++ b/OCR API/e_way_bill.py
@@ -1,5 +1,5 @@
 import re
-from ocr_utils import normalize_ascii, debug_print_lines
+from ocr_utils import normalize_ascii, debug_print_lines, STATE_REGEX
 
 def extract_eway_bill_fields(text):
     print("\n🧾 Processing: E-Way Bill")
@@ -71,15 +71,19 @@ def extract_eway_bill_fields(text):
     for i, line in enumerate(lines):
         norm = normalize_ascii(line)
         if "dispatch from" in norm:
-            for j in range(i, i+5):
-                if j < len(lines) and any(st in lines[j].upper() for st in ["MAHARASHTRA", "GUJARAT", "DELHI", "TAMIL", "KARNATAKA"]):
-                    result["From State"] = lines[j].strip().split()[-1].title()
-                    break
+            for j in range(i, i + 5):
+                if j < len(lines):
+                    match = STATE_REGEX.search(lines[j])
+                    if match:
+                        result["From State"] = match.group(1).title()
+                        break
         if "ship to" in norm:
-            for j in range(i, i+5):
-                if j < len(lines) and any(st in lines[j].upper() for st in ["MAHARASHTRA", "GUJARAT", "DELHI", "TAMIL", "KARNATAKA"]):
-                    result["To State"] = lines[j].strip().split()[-1].title()
-                    break
+            for j in range(i, i + 5):
+                if j < len(lines):
+                    match = STATE_REGEX.search(lines[j])
+                    if match:
+                        result["To State"] = match.group(1).title()
+                        break
 
     # 6️⃣ Material name / Plastic Category
     material_line = find(r"Product\s+Name\s+&\s+Desc[^\n]*\n\s*([A-Z\s&]+)")

--- a/OCR API/ocr_utils.py
+++ b/OCR API/ocr_utils.py
@@ -3,6 +3,52 @@ import re
 import unicodedata
 from PIL import Image
 
+# Common reference list of Indian state and union territory names
+INDIAN_STATES = [
+    "ANDHRA PRADESH",
+    "ARUNACHAL PRADESH",
+    "ASSAM",
+    "BIHAR",
+    "CHHATTISGARH",
+    "GOA",
+    "GUJARAT",
+    "HARYANA",
+    "HIMACHAL PRADESH",
+    "JHARKHAND",
+    "KARNATAKA",
+    "KERALA",
+    "MADHYA PRADESH",
+    "MAHARASHTRA",
+    "MANIPUR",
+    "MEGHALAYA",
+    "MIZORAM",
+    "NAGALAND",
+    "ODISHA",
+    "PUNJAB",
+    "RAJASTHAN",
+    "SIKKIM",
+    "TAMIL NADU",
+    "TELANGANA",
+    "TRIPURA",
+    "UTTAR PRADESH",
+    "UTTARAKHAND",
+    "WEST BENGAL",
+    "ANDAMAN AND NICOBAR ISLANDS",
+    "CHANDIGARH",
+    "DADRA AND NAGAR HAVELI AND DAMAN AND DIU",
+    "DELHI",
+    "JAMMU AND KASHMIR",
+    "LADAKH",
+    "LAKSHADWEEP",
+    "PUDUCHERRY",
+]
+
+# Regex pattern to match any of the above state names as whole words
+STATE_REGEX = re.compile(
+    r"\b(" + "|".join(re.escape(s) for s in INDIAN_STATES) + r")\b",
+    re.IGNORECASE,
+)
+
 def run_ocr(image_path):
     from google.cloud import vision  # Import inside function
     client = vision.ImageAnnotatorClient()  # Initialize here
@@ -137,18 +183,14 @@ def extract_states_from_blocks(lines):
         # print(f"🔍 At line {i}, cleaned line: '{clean_line}'")  # Log every line for debugging
 
         if clean_line == "from" and i + 2 < len(lines):
-            # print(f"📍 Found 'From' at line {i}: {line.strip()}")
-            # print(f"   Checking line {i+2} for state: {lines[i+2].strip()}")
-            match = re.search(r"\(([^)]+)\)", lines[i + 2])
+            match = STATE_REGEX.search(lines[i + 2])
             if match:
-                from_state = match.group(1).strip()
+                from_state = match.group(1).title()
 
         elif re.fullmatch(r"to", clean_line.strip()) and i + 2 < len(lines):
-            # print(f"📍 Found 'To' at line {i}: {line.strip()}")
-            # print(f"   Checking line {i+2} for state: {lines[i+2].strip()}")
-            match = re.search(r"\(([^)]+)\)", lines[i + 2])
+            match = STATE_REGEX.search(lines[i + 2])
             if match:
-                to_state = match.group(1).strip()
+                to_state = match.group(1).title()
 
 
     return from_state, to_state


### PR DESCRIPTION
## Summary
- add list of `INDIAN_STATES` to ocr utils
- use that list to look up states in e-way bill parsing
- compile regex to detect state names
- search with that regex when parsing

## Testing
- `git ls-files '*.py' -z | xargs -0 python3 -m py_compile`


------
https://chatgpt.com/codex/tasks/task_e_68416f8ba6d0832581d6be64d4aefc29